### PR TITLE
`slnode debug` enhancements

### DIFF
--- a/lib/commands/debug.js
+++ b/lib/commands/debug.js
@@ -2,6 +2,8 @@ var fork = require('child_process').fork;
 var fs = require('fs');
 var path = require('path');
 var open = require('opener');
+var inspector = require('node-inspector');
+
 var parserOptions = {
   suspend: {
     alias: 's',
@@ -42,9 +44,15 @@ function debug(argv, options, loader) {
 
   var inspectorPort = options.port || 8080;
   var inspectorArgs = ['--web-port=' + inspectorPort];
+
   var subprocPort = options['debug-port'] || 5858;
   var subprocExecArgs = ['--debug=' + subprocPort];
-  var url = 'http://127.0.0.1:' + inspectorPort + '/debug?port=' + subprocPort;
+
+  var url = inspector.buildInspectorUrl(
+    'localhost',
+    inspectorPort,
+    subprocPort
+  );
 
   if (options.suspend) {
     subprocExecArgs.push('--debug-brk');

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "commander": "~1.1.1",
     "slnode-create": "git+ssh://git@github.com:strongloop/slnode-create.git",
     "optimist": "~0.5.0",
-    "node-inspector": "~0.3.0-preview1",
+    "node-inspector": "~0.3.2",
     "opener": "~1.3.0"
   }
 }


### PR DESCRIPTION
See SLN-331.
1. It is possible to run slnode debug without extra parameters. The script should look into package.json to figure out what is the application's main script.
2. The node-inspector should start with the main module file opened and focused. Requires node-inspector changes - see [the pull request](https://github.com/node-inspector/node-inspector/pull/172).

/cc: @Schoonology please review.
