### PR TITLE
slnode unit tests, two styles, NOT WORKING!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lib-cov
 
 pids
 logs
+out-*
 results
 
 npm-debug.log

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+# Makefile: npm and test wrapper
+
+CLI=slnode
+
+PATH:=$(PWD)/bin:$(PATH)
+export PATH
+
+.PHONY: test-make
+test-make: test-clean
+	echo PATH=$$PATH
+	./bin/$(CLI) create cli out-cli
+	./bin/$(CLI) create web out-web
+	./bin/$(CLI) create out-default
+	./bin/$(CLI) create module out-module
+	./bin/$(CLI) create package out-package
+
+.PHONY: test-clean
+test-clean:
+	rm -rf out-* lib/out-*

--- a/package.json
+++ b/package.json
@@ -15,6 +15,12 @@
     "sn": "./bin/slnode"
   },
   "scripts": {
+    "blanket": {
+      "pattern": "//^((?!(node_modules|test)).)*$/"
+    },
+    "coverage": "./node_modules/.bin/mocha -r blanket -R html-cov > coverage.html",
+    "test": "mocha --reporter spec",
+    "lint": "./node_modules/.bin/jshint *.js test lib"
   },
   "dependencies": {
     "npm": "git+ssh://git@github.com:strongloop/npm.git",
@@ -22,6 +28,13 @@
     "slnode-create": "git+ssh://git@github.com:strongloop/slnode-create.git",
     "optimist": "~0.5.0",
     "node-inspector": "~0.3.2",
-    "opener": "~1.3.0"
+    "opener": "~1.3.0",
+    "debug": "~0.7.2"
+  },
+  "devDependencies": {
+    "mocha": "~1.9.0",
+    "jshint": "~2.0.1",
+    "blanket": "~1.1.4",
+    "fs.extra": "~1.2.1"
   }
 }

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,0 +1,50 @@
+var assert = require('assert');
+var debug = require('debug')('cli');
+var exec = require('child_process').exec;
+var fs = require('fs.extra');
+var path = require('path');
+
+// cli spawns itself as a child process... this is quite sucky, not sure why it
+// doesn't do require('npm').install(), but anyhow, it means we must put our own
+// bin/ folder at the beginning of the path.
+process.env.PATH = path.resolve('./bin') + path.delimiter + process.env.PATH;
+
+debug('PATH:', process.env.PATH);
+
+var CLI = 'slnode';
+
+function cli(args) {
+  return CLI + ' ' + args;
+}
+
+function assertRunOk(cmd, callback) {
+  debug('exec cmd:', cmd);
+
+  var child = exec(cmd, function(err, stdout, stderr) {
+    debug('exec cmd returned: exit=', child.exitCode, err, stdout, stderr);
+    if(err) throw err;
+    assert.equal(child.exitCode, 0, 'cmd exits with ok');
+    assert.equal(stderr, '', 'cmd exits with ok');
+    return callback(err, stdout, stderr);
+  });
+  return child;
+}
+
+describe('cli create', function() {
+  beforeEach(function() {
+    fs.rmrfSync('out-web');
+  });
+
+  it('should create web with name', function(done) {
+    assertRunOk(cli('create web out-web'), done);
+  });
+});
+
+describe('cli', function() {
+  it('should print usage when called with no arguments', function(done) {
+    assertRunOk(cli(''), function(err, stdout, stderr) {
+      assert(new RegExp('Usage: ' + CLI).test(stdout));
+      return done();
+    });
+  });
+});


### PR DESCRIPTION
`make test` is totally cheesy... but it works.
`npm test` is better, but triggers obscure internal errors in the
npm-cli relating to multi registry support... only sometimes.

At one point npm test was passing, after I started to used execFile
instead of fork to call npm-cli, then it started failing again. Also, at
one point it was passing, but then I did a `npm uninstall -g slnode`
which caused it to start failing... but `npm install -g slnode` didn't
cause if to pass again.

/to @piscisaureus @bajtos  Can one of you look at this? I'm quite stuck, and its trivially reproduceable (npm install; make test-make; npm test). See message above, without some pretty deep diving into npm, I don't know why I (and a Makefile) can call slnode create, but npm test cannot without erroring in npm multi-regi:

```
       1 | Error: Configuration doesn't specify multiple registries<LF>
       2 |     at new MultiRegClient (/home/sam/w/slnode/slnode/node_modules/npm/node_modules/npm-multiple-registries/index.js:92:11)<LF>
       3 |     at Object.createClient (/home/sam/w/slnode/slnode/node_modules/npm/node_modules/npm-multiple-registries/index.js:230:12)<LF>
       4 |     at /home/sam/w/slnode/slnode/node_modules/npm/lib/npm.js:322:31<LF>
       5 |     at /home/sam/w/slnode/slnode/node_modules/npm/node_modules/npmconf/npmconf.js:76:7<LF>
       6 |     at Array.forEach (native)<LF>
       7 |     at /home/sam/w/slnode/slnode/node_modules/npm/node_modules/npmconf/npmconf.js:75:13<LF>
       8 |     at /home/sam/w/slnode/slnode/node_modules/npm/node_modules/once/once.js:17:15<LF>
       9 |     at Conf.<anonymous> (/home/sam/w/slnode/slnode/node_modules/npm/node_modules/npmconf/npmconf.js:117:9)<LF>
      10 |     at Conf.g (events.js:175:14)<LF>
```

/cc @ritch I'm a bit luke-warm about the whole "cli as a git-like bundle of clis" after this slnode renaming exercise. slnode calling slnode-create, calling slnode install, calling npm install... Likely the problem is mostly cut-n-paste of spawn calls in slnode, and inconsistent or missing error checks on the success/failure of the sub-command, but some library and test support is definitely required if we are going to use executable sub-commands as our loopback integration strategy.
