### PR TITLE
Makefile: fix OS X, hint on missing ronn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,19 @@ MKD = $(wildcard man/*.md)
 TXT = $(MKD:.md=)
 
 .PHONY: man
-man: $(TXT)
+man: check-ronn $(TXT)
 
 man/%.md2: man/%.md
 	perl -pes'/^#//' < $< > $@
 
-man/%.roff: man/%.md2
+man/%.roff: man/%.md2 $(RONN)
 	ronn --pipe -r $< > $@
 
 man/%: man/%.roff
-	man -Tascii $< > $@
+	groff -Tascii -mandoc -c $< > $@
+
+check-ronn:
+ifeq ($(shell which ronn),)
+	$(error Cannot find `ronn` executable. \
+	Install it by running `gem install ronn` or `apt-get install ruby-ronn`)
+endif


### PR DESCRIPTION
Replaced `man -Tascii` with `groff -Tascii -mandoc -c` to make the build
process work on Mac OS X.

Added a check that prints installation instructions when `ronn` is not found.

@sam-github please review.
