### PR TITLE
Create command refactor

### DIFF
--- a/lib/commands/create.js
+++ b/lib/commands/create.js
@@ -16,6 +16,10 @@ function create(argv, options, loader) {
   var name = options._[1];
   var Gen = Generator.fromType(type);
 
+  if(!name) {
+    return console.log(loader.getUsage('create'));
+  }
+
   if(!Gen) {
     loader.error(new Error(type + ' is not a supported boilerplate type'));
     return;


### PR DESCRIPTION
@sam-github can you take a look?
- adds compatibility for slc-create v0.2
- removes shim for create method
- uses `lib/loader` instead of `commander`

For more info on slc-create v0.2 see:
https://github.com/strongloop/slc-create/pull/13
