### PR TITLE
Module not found is not an error for slc commands

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -132,7 +132,7 @@ function loadCommand(name) {
   try {
     module = require(path.resolve(this.root, String(name)));
   } catch (e) {
-    if (e) {
+    if (e && e.code !== 'MODULE_NOT_FOUND') {
       console.error('There was an error loading module "%s":\n', name, e);
     }
     return null;


### PR DESCRIPTION
slc falls back to using npm or run, if it can't find a command. See
SLN-421.

/to @bajtos 
