### PR TITLE
strongops,test: code cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,3 @@ For more information see the help for the create command.
 
     $ slc create -h
 
-## Note on `npm test`
-
-To have the tests work on your system, type:
-
-    $ export SLC_TEST=1
-
-This changes what slc considers home, for the strongops command.

--- a/lib/commands/strongops.js
+++ b/lib/commands/strongops.js
@@ -630,19 +630,18 @@ function getDefaults() {
 }
 exports.test.getDefaults = getDefaults;
 
+exports.userHome = process.env[
+  (process.platform === 'win32') ? 'USERPROFILE'  : 'HOME'
+];
+
 /**
  * Get the path to the user's home directory in a platform independent way.
  * @returns {String} The path to the user's home directory.
  */
 function getUserHome() {
-  // if running under Jenkins to set HOME into test and grab
-  // values from there
-  if (process.env.JENKINS_HOME || process.env.SLC_TEST) {
-    return path.join(process.cwd(), 'test');
-  }
-  return process.env[(process.platform === 'win32') ? 'USERPROFILE' : 'HOME'];
+  return exports.userHome;
 }
-exports.test.getUserHome = getUserHome;
+
 
 /**
  * Get user name and email from .gitconfig, if possible.
@@ -664,7 +663,7 @@ function getGitConfigInfo() {
 
   return obj;
 }
-exports.test.getGitConfigInfo = getGitConfigInfo;
+exports.test.gitConfig = getGitConfigInfo;
 
 /**
  * Get email from ~/.npmrc if possible.
@@ -680,7 +679,7 @@ function getNpmEmail() {
     return npmrc.email;
   return undefined;
 }
-exports.test.getNpmEmail = getNpmEmail;
+exports.test.npmEmail = getNpmEmail;
 
 /**
  * A convenience function to return the schema for the prompt data.

--- a/test/.gitconfig
+++ b/test/.gitconfig
@@ -1,3 +1,3 @@
 [user]
-    name = Edmond Meinfelder
-    email = edmond@stdarg.com
+    name = GitConfig Name
+    email = gitconfig@example.com

--- a/test/.npmrc
+++ b/test/.npmrc
@@ -1,1 +1,1 @@
-email = edmond@stdarg.com
+email = npmrc@example.com

--- a/test/config.js
+++ b/test/config.js
@@ -7,34 +7,23 @@
 var fs = require('fs');
 var path = require('path');
 
-// We need to fudge a bit for Jenkins. If under Jenkins, we point to ./test as the home directory
-var home = isRunningOnJenkins() ?
-  path.join(process.cwd(), 'test') :
-  process.env.HOME;
+// This is a duplication of the same code in the module under test
+// (i.e. stronops.js) It's questionable whether such test brings any benefit
+var home = process.env[(process.platform === 'win32') ? 'USERPROFILE'  : 'HOME'];
 
 var getFileSyncFile = path.join(home, '.gitconfig');
 
-var gitConfig = fs.readFileSync(path.join(home, '.gitconfig'), 'utf-8');
-var npmConfig = fs.readFileSync(path.join(home, '.npmrc'), 'utf-8');
-
+/**
+ * Configuration options as set in test gitconfig and npmrc
+ */
 exports.strongops = {
-  getNpmEmail: getFromRc(npmConfig, 'email', 'edmond@stdarg.com'),
-  getGitConfigInfo: {
-    name: getFromRc(gitConfig, 'name', 'Edmond Meinfelder'),
-    email: getFromRc(gitConfig, 'email', 'edmond@stdarg.com'),
+  npmEmail: 'npmrc@example.com',
+  gitConfig: {
+    name: 'GitConfig Name',
+    email: 'gitconfig@example.com'
   },
-  getUserHome: home,
-  getFileSync: getFileSyncFile,
+  userHome: home,
+  anExistingFile: path.resolve(__dirname, '.gitconfig')
 };
 
-exports.strongops.getDefaults = exports.strongops.getGitConfigInfo;
-
-function isRunningOnJenkins() {
-  return process.env.JENKINS_HOME || process.env.SLC_TEST;
-}
-
-function getFromRc(rcText, localName, defaultValue) {
-  var regex = new RegExp('^\\s*' + localName + '\\s*=\\s*(.*)\\s*$', 'm');
-  var match = rcText.match(regex);
-  return match ? match[1] : defaultValue;
-}
+exports.strongops.getDefaults = exports.strongops.gitConfig;

--- a/test/strongops.js
+++ b/test/strongops.js
@@ -1,36 +1,45 @@
 var assert = require('assert');
+var path = require('path');
 var is = require('is2');
 var strops = require('../lib/commands/strongops');
 var test = require('./config').strongops;
 
+var originalUserHome = strops.userHome;
+
+beforeEach(function() { strops.userHome = originalUserHome; });
+
 describe('getNpmEmail', function() {
   it('Should return the email string from ~/.npmrc', function() {
-    assert.equal(test.getNpmEmail, strops.test.getNpmEmail());
+    givenUserHomeInTestFolder();
+    assert.equal(test.npmEmail, strops.test.npmEmail());
   });
 });
 
 describe('getGitConfigInfo', function() {
   it('Should return the user name and email string from ~/.gitconfig', function() {
-    var git = strops.test.getGitConfigInfo();
-    assert.deepEqual(git, strops.test.getGitConfigInfo());
+    givenUserHomeInTestFolder();
+    var git = strops.test.gitConfig();
+    assert.deepEqual(git, strops.test.gitConfig());
   });
 });
 
 describe('getUserHome', function() {
   it('Should return the home directory for the user', function() {
-    assert.equal(test.getUserHome, strops.test.getUserHome());
+    assert.equal(test.userHome, strops.userHome);
   });
 });
 
 // FIXME: make another test with a config, to test .npmrc email retrieval
 describe('getDefaults', function() {
   it('Should get the defaults from ~/.gitconfig and possibly ~/.npmrc', function() {
+    givenUserHomeInTestFolder();
     assert.deepEqual(test.getDefaults, strops.test.getDefaults());
   });
 });
 
 describe('getCmdLineOverrides', function() {
   it('Given an empty options object, should an empty object', function() {
+    givenUserHomeInTestFolder();
     assert.deepEqual({}, strops.test.getCmdLineOverrides());
   });
 });
@@ -88,7 +97,10 @@ describe('getFileSync', function() {
 describe('getFileSync', function() {
   it('Should return the contents of a file when file is present.', function() {
     //console.log('getFileSync:', test.getFileSync);
-    assert.ok(is.nonEmptyStr(strops.test.getFileSync(test.getFileSync)) === true);
+    assert.ok(is.nonEmptyStr(strops.test.getFileSync(test.anExistingFile)) === true);
   });
 });
 
+function givenUserHomeInTestFolder() {
+  strops.userHome = path.resolve(__dirname);
+}


### PR DESCRIPTION
Removed checks for SLC_TEST and JENKINS_HOME from lib/commands/strongops.js.

Cleaned up test/strongops.js and test/config.js, so that they always use the test npmrc and gitconfig.

Renamed emails, usernames and test-data-properties to make their intention easier to understand.

The commit addresses comments in f3c3718.

@sam-github @stdarg Please review. You may have different opinion on some of the changes I made, I am happy to discuss my rationale behind them and incorporate your feedback into the code.
