### PR TITLE
Fix typo, save correct data locally

### DIFF
--- a/lib/commands/strongops.js
+++ b/lib/commands/strongops.js
@@ -177,7 +177,7 @@ function doUserReg(overrides, defaults, options, cb) {
     strongOpsRegister(userEnteredData, options, function(err, userData) {
       if (err)  return cb(err);
       console.log('\nYou are now registered. Welcome to StrongOps!');
-      cb(undefined, userEnteredData);
+      cb(undefined, userData);
     });
   });
 }


### PR DESCRIPTION
The submitted data (username, PASSWORD) was being saved, instead of the
response data.

/to @stdarg Is this the correct fix for SLN-489?
