### PR TITLE
Report sls suite version

### DIFF
--- a/lib/commands/version.js
+++ b/lib/commands/version.js
@@ -2,8 +2,13 @@
  * Output version
  */
 
-module.exports = function (argv, options, loader) {
-  var v = require('../../package.json').version;
+var json = require('../../package.json');
 
-  console.log('strongnode', v, '(node ' + process.version + ')');
+module.exports = function (argv, options, loader) {
+  var sn = json.version;
+  var node = process.version;
+  var sls = json.slsVersion;
+
+  console.log('strongloop suite v%s, strongnode v%s (node %s)',
+             sls, sn, node);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "slc",
   "version": "1.2.0",
+  "slsVersion": "1.0.0",
   "description": "Strongloop node command line",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Note that it is not possible for the slc git repository to know the
strongloop suite version... the actual version will be replaced at
distribution build time.

/to @cgole @altsang  Is this what you would like for SLN-520?

Output looks like:

```
% slc version 
strongloop suite v1.0.0, strongnode v1.2.0 (node v0.10.18)
```
