### PR TITLE
clusterctl: document the stop command

### DIFF
--- a/man/clusterctl
+++ b/man/clusterctl
@@ -25,6 +25,8 @@ OOPPTTIIOONNSS
 
        +o   sseett--ssiizzee: set-size N, set cluster size to N workers
 
+       +o   ssttoopp: stop the cluster controller
+
        +o   ddiissccoonnnneecctt: disconnect all workers
 
        +o   ffoorrkk: fork one worker
@@ -41,4 +43,4 @@ EExxaammpplleess
 
                slc clusterctl -p /apps/my-app/clusterctl status
 
-                                September 2013                    CLUSTERCTL()
+                                 October 2013                     CLUSTERCTL()

--- a/man/clusterctl.md
+++ b/man/clusterctl.md
@@ -19,6 +19,7 @@ Supported commands are:
 
 - `status`: report status of cluster workers, the default command
 - `set-size`: set-size N, set cluster size to N workers
+- `stop`: stop the cluster controller
 - `disconnect`: disconnect all workers
 - `fork`: fork one worker
 


### PR DESCRIPTION
See strongloop/strong-cluster-control#17, this documents the stop command in slc.
