### PR TITLE
Create examples from an internal copy

### DIFF
--- a/lib/example.js
+++ b/lib/example.js
@@ -10,83 +10,60 @@ var colors = require('colors'); // XXX(sam) don't need to assign to colors
 var debug = require('debug')('slc');
 var fs = require('fs.extra');
 var path = require('path');
-var install = require('./install');
-var spawn = require('child_process').spawn;
 
-// We would like to checkout vX.Y.Z tag, but checking out tags spits warnings
-// about detached heads... which isn't good, and I don't want to sweat this too
-// much, all the git code should be replaced, anyhow. So, I remove the .Z patch
-// number from the version in order to checkout a branch.
-var VERSION = 'v' + require('../package.json').version.replace(/\.\d$/, '');
+// fs.extra won't copy the symlinks in node_modules/.bin, ncp does :-(
+fs.copyRecursive = require('ncp').ncp;
 
 function example(argv, options, loader, type, repo, name) {
-  console.log('Creating %s example in %s (this may take a moment)', type, name);
+  // Fail on existing paths
+  try {
+    fs.lstatSync(name);
+    return loader.error('Cannot create example at %s: Path exists', name);
+  } catch(err) {
+    // Expected that name does not exist
+  }
 
-  // URL schemes:
-  //
-  // git@github.com URLs require a github account and ssh credentials
-  //
-  // var url = 'http://github.com/strongloop/' + repo + '.git';
-  //
-  // http and https URLs work best, but git will prompt for a password for
-  // the sls-sample-app until it is made public at launch.
-  //
-  // git protocol is inherently read-only, so also seems to work well, but
-  // not with the private sls-sample-app
-  //
-  // Note the following undocumented feature for SL developers:
-  //
-  //    slc example suite --protocol=http
+  // Create target path, in case intermediate directories need to be made (ncp
+  // doesn't handle that).
+  try {
+    fs.mkdirRecursiveSync(name);
+  } catch(err) {
+    return loader.error('Cannot create example at %s: %s', name, err);
+  }
 
-  var protocol = options.protocol || 'http';
-  var url = protocol + '://github.com/strongloop/' + repo + '.git';
-  var command = 'git clone --quiet --depth 1 ' + url + ' ' + name +
-    ' --branch ' + VERSION;
+  console.log('Creating %s example in %s', type, name);
 
-  debug('example <%s>', command);
+  var srcDir = path.resolve(__dirname, '..', 'node_modules', repo);
 
-  var git = (process.platform === 'win32') ?
-    spawn('cmd.exe', ['/c', command], {stdio: [0,1,2]}) :
-    spawn('/bin/sh', ['-c', command], {stdio: [0,1,2]});
+  debug('copy %s to %s', srcDir, name);
 
-  git.once('error', function (err) {
-    debug('git spawn errored with', err);
-    switch(err.code) {
-    case 128:
-      loader.error(err.message);
-      break;
-    default:
-      loader.error('An unknown error occured:\n' + err.message);
-      break;
-    }
-  });
-
-  git.once('exit', function (exitCode, signal) {
-    fs.removeSync(path.join(name, '.git'));
-    if(exitCode === 0) {
-      if(options.install === false) {
-        return promptToRun(null, true);
-      }
-      console.log('Installing...');
-      process.chdir(name);
-      install(promptToRun);
-    } else {
-      console.error('git exited with code %s (`%s`)', exitCode, command);
-      process.exit(exitCode);
-    }
-  });
-
-  function promptToRun(err, needsInstall) {
+  fs.copyRecursive(srcDir, name, function(err) {
     if(err) {
-      loader.error(err);
-    } else {
-      console.log();
-      console.log('Run the example:');
-      console.log('  $ cd', name.green);
-      if(needsInstall) {
-        console.log('  $ slc install');
-      }
-      console.log('  $ slc run .');
+      // err is not an Error, in violation of all things node, its an array of
+      // Error, take the first
+      err = err.shift();
+      return loader.error('Failed to create example at %s: %s', name, err);
     }
+
+    // Its faster and more robust to copy everything, and delete what we don't
+    // want. Particularly because the semantics of various recursive copy
+    // implementations I tried were bizarre with the various combinations of
+    // src/dst files and directories.
+    if(options.install === false) {
+      var moduleDir = path.join(name, 'node_modules');
+      debug('remove installed module dir', moduleDir);
+      fs.removeSync(moduleDir);
+    }
+    return prompt();
+  });
+
+  function prompt() {
+    console.log();
+    console.log('Run the example:');
+    console.log('  $ cd', name.green);
+    if(options.install === false) {
+      console.log('  $ slc install');
+    }
+    console.log('  $ slc run .');
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,12 @@
     "mkdirp": "~0.3.5",
     "which": "~1.0.5",
     "strong-cluster-control": "git+ssh://git@github.com:strongloop/strong-cluster-control.git",
-    "fs.extra": "~1.2.1"
+    "sls-sample-app": "strongloop/sls-sample-app",
+    "sn-example-blog": "strongloop/sn-example-blog",
+    "sn-example-chat": "strongloop/sn-example-chat",
+    "sn-example-urlsaver": "strongloop/sn-example-urlsaver",
+    "fs.extra": "~1.2.1",
+    "ncp": "~0.4.2"
   },
   "devDependencies": {
     "automation": "git+ssh://git@github.com:strongloop/automation.git",


### PR DESCRIPTION
- removes any dependency on git, fixing the bugs related to git
  versions and/or non-existence, and requirements for network access
- allowes us to utilize our release-engineering dependency resolution
  tools, rather than the built-in clone from branch, which had bugs
  reported against it
- drastically shortens and simplifies the implementation

TODO add some more tests. there was only one existing test.

/to @ritch Look OK to you?

Note, this depends on sr-sln-537 branches of sn-example-chat and sn-example-urlsaver, because the repo names and package names for those two were not synced. I could add an additional mapping... but that lack of sync will confuse both people, and also the release-engineering dep resolution tools, so I thought better to change the name in package.json.
