### PR TITLE
Make sample npm deps be complete

### DIFF
--- a/npm-update-examples
+++ b/npm-update-examples
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+set -x
+
+(cd node_modules/sls-sample-app; npm update)
+(cd node_modules/sn-example-blog; npm update)
+(cd node_modules/sn-example-chat; npm update)
+(cd node_modules/sn-example-urlsaver; npm update)

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "lint": "./node_modules/.bin/jshint --exclude test/sandbox *.js lib test",
     "docs": "./node_modules/.bin/sdocs --out docs",
-    "test": "./node_modules/.bin/mocha --reporter list"
+    "test": "./node_modules/.bin/mocha --reporter list",
+    "postinstall": "./npm-update-examples"
   },
   "dependencies": {
     "npm": "git+ssh://git@github.com:strongloop/npm.git",


### PR DESCRIPTION
npm hoists shared deps higher in the tree, but since we install the
samples by direct recursive copy from node_modules/, they end up not
having complete dependencies. Calling `npm update` in the samples fills
in there deps to make them complete.

SLN-635
