### PR TITLE
strongops cmd now uses public json-file-plus.

### DIFF
--- a/lib/commands/strongops.js
+++ b/lib/commands/strongops.js
@@ -477,7 +477,7 @@ function saveCredentialsToFile(data, file, cb) {
     if (err) return cb(err);
 
     fileObj.set(data);
-    fileObj.save(file, function(err) {
+    fileObj.save(function(err) {
       return cb(err);
     });
   });

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "async": "~0.2.9",
     "commander": "~1.1.1",
     "ini": "~1.1.0",
-    "json-file-plus": "strongloop/node-json-file",
+    "json-file-plus": "~0.2.2",
     "optimist": "~0.5.0",
     "node-inspector": "~0.5.0",
     "opener": "~1.3.0",


### PR DESCRIPTION
to: @sam-github 

There was a bug that has since been fixed. Was able to swap in public version of json-file-plus with 1 change.
