### PR TITLE
Support the --no-install option for `slc lb`

### DIFF
--- a/lib/commands/lb.js
+++ b/lib/commands/lb.js
@@ -58,19 +58,26 @@ module.exports = function (argv, options, loader) {
         if(err) return error(err);
 
         process.chdir(dir);
-        install(function() {
-          printNextSteps();
-        });
+        if (options.install !== false) {
+          install(function() {
+            printNextSteps();
+          });
+        } else {
+          printNextSteps(true);
+        }
       });
     } else {
       error('<name> is required when running `slc lb project <name>`!');
     }
 
-    function printNextSteps() {
+    function printNextSteps(needsInstall) {
       console.log();
       console.log('Create a model in your app:');
       console.log('  $ cd', dir.green);
       console.log('  $ slc lb model product -i');
+      if (needsInstall) {
+        console.log('  $ slc install');
+      }
       console.log('Run your Project:');
       console.log('  $ slc run .');
     }

--- a/man/lb
+++ b/man/lb
@@ -15,17 +15,18 @@ CCOOMMMMAANNDDSS
 
              $ slc lb workspace my-loopback-workspace
 
-       pprroojjeecctt <<nnaammee>>
+       pprroojjeecctt <<nnaammee>> [[----nnoo--iinnssttaallll]]
        Create a LoopBack application in a new  directory  within  a  workspace
-       using the given name. The _n_a_m_e argument is required.
+       using the given name. The _n_a_m_e argument is required. With ----nnoo--iinnssttaallll,
+       will not install the npm dependencies.
 
              $ cd my-loopback-workspace
              $ slc lb project my-app
              $ slc run my-app # to run the app
 
        mmooddeell <<nnaammee>>
-       Create  a  model  in  an  existing LoopBack application using the given
-       name. If you provide  the  --ii  or  ----iinntteerraaccttiivvee  flags,  you  will  be
+       Create a model in an existing  LoopBack  application  using  the  given
+       name.  If  you  provide  the  --ii  or  ----iinntteerraaccttiivvee  flags, you will be
        prompted through a model configuration. The _n_a_m_e argument is required.
 
              $ cd my-app
@@ -47,14 +48,14 @@ OOPPTTIIOONNSS
               command.
 
        ----ddaattaa--ssoouurrccee <<nnaammee>>
-              Supply  a  custom data source when creating a model. Defaults to
+              Supply a custom data source when creating a model.  Defaults  to
               "db".
 
        ----pprriivvaattee
               Do not expose the model's API remotely.
 
        --cc, ----ccoonnnneeccttoorr
-              Specify  the  connector  name   when   creating   a   datasource
+              Specify   the   connector   name   when  creating  a  datasource
               (required).
 
                                  November 2013                            LB()

--- a/man/lb.md
+++ b/man/lb.md
@@ -14,9 +14,10 @@ Supported `lb` commands are:
 
         $ slc lb workspace my-loopback-workspace
 
-* `project <name>`:
+* `project <name> [--no-install]`:
   Create a LoopBack application in a new directory within a workspace
-  using the given name. The <name> argument is required.
+  using the given name. The <name> argument is required. With `--no-install`,
+  will not install the npm dependencies.
 
         $ cd my-loopback-workspace
         $ slc lb project my-app

--- a/test/lb.js
+++ b/test/lb.js
@@ -12,10 +12,6 @@ var spawnCli = runner.spawnCli;
 var Project = require('loopback-workspace').models.Project;
 
 describe('lb', function() {
-  // 45 seconds for project install has been observed on dev machine, I will
-  // allow ten times this for CI
-  this.timeout(10 * 45 * 1000);
-
   describe('lb workspace', function() {
     beforeEach(sandbox.reset);
 
@@ -55,7 +51,11 @@ describe('lb', function() {
     beforeEach(sandbox.reset);
 
     it('creates a loopback project', function(done) {
-      createProject('test-project', done);
+      // 45 seconds for project install has been observed on dev machine, I will
+      // allow ten times this for CI
+      this.timeout(10 * 45 * 1000);
+
+      createProject('test-project', done, true);
     });
     it('fails without a name argument', function(done) {
       assertFailsWithoutName('project', done);
@@ -104,15 +104,21 @@ describe('lb', function() {
   });
 });
 
-function createProject(projectName, done) {
-  spawnCliInSandbox(['lb', 'project', projectName])
+function createProject(projectName, done, install) {
+  var installOption = install ? '--install' : '--no-install';
+  spawnCliInSandbox(['lb', 'project', projectName, installOption])
     .run(function(err) {
       if (err) return done(err);
       var rootFiles = fs.readdirSync(sandbox.path(projectName)).sort();
-      expect(rootFiles).to.eql([
+      // node_modules exist only if project is installed
+      var expectFiles = [
         'app.js', 'models', 'package.json', 'models.json',
-        'datasources.json', 'app.json', 'node_modules'
-      ].sort());
+        'datasources.json', 'app.json'
+      ];
+      if(install) {
+        expectFiles.push('node_modules');
+      }
+      expect(rootFiles).to.eql(expectFiles.sort());
       done();
     });
 }


### PR DESCRIPTION
create and  example support --no-install. very useful in tests or other auto tooling, installing every time takes lots of time

very useful when setting up git repos, you can create the project, but not all the cruft you don't want committed

I will squash the !commit messages down. Had bit of an epic day of it, trying to get CI to run the lb project sub-command. Not yet ready to believe its working.
