### PR TITLE
Improve 'slc version' tests

### DIFF
--- a/test/version.js
+++ b/test/version.js
@@ -6,6 +6,19 @@ var fs = require('fs');
 var sandbox = require('./helpers/sandbox.js');
 var spawnCliInSandbox = require('./helpers/runner.js').spawnCliInSandbox;
 
+function assertMatch(actual, pattern, message) {
+  if (!pattern.test(actual)) {
+    assert.fail(actual, pattern, message, 'matches');
+  }
+}
+
+function assertContains(actual, needle, message) {
+  if (actual.indexOf(needle) === -1) {
+    message = message || ('Expected "' + actual + '" to contain "' + needle + '"');
+    assert.fail(actual, needle, message, 'contains');
+  }
+}
+
 describe('version', function() {
   before(function() {
     sandbox.reset();
@@ -19,7 +32,8 @@ describe('version', function() {
         assert.equal(status, 0);
         assert.equal(stdout.length, 1);
         var line0 = stdout[0];
-        assert(/^slc v[.0-9]* .node v[.0-9]*.$/.test(line0));
+        assertMatch(line0, /^slc v[.0-9]* .node v.+$/);
+        assertContains(line0, process.version);
         return done();
       });
   });


### PR DESCRIPTION
Uses custom asserts for improved failure output and validates against actual node version string, as it is completely configurable at compile time and is therefore runtime dependent.
