### PR TITLE
Handle username for strongops command

### DIFF
--- a/lib/commands/strongops.js
+++ b/lib/commands/strongops.js
@@ -199,6 +199,9 @@ function doUserReg(overrides, defaults, options, cb) {
       console.log(
         '\nYou are now registered. Welcome to StrongOps!\n' +
         '\n' +
+        'Restart your app and go to https://strongops.strongloop.com to see\n' +
+        'the stats reported by your app in the dashboard.\n' +
+        '\n' +
         'Note that what you specified for "username" is the login you will\n' +
         'use on https://www.strongloop.com or https://strongops.strongloop.com\n' +
         '\n' +


### PR DESCRIPTION
cc @sam-github 

Take username for authentication or new registrations.

Adjusted the error handling based on NodeFly/nodefly-registration now
always returning an error object for errors.

Changes messaging to communicate that the username is the login for
either strongloop.com or strongops.

Can be tested against new api on staging by setting `SL_OPS_REGISTER_API=https://strongops-staging.strongloop.com/ops/rest/`
