### PR TITLE
Handle username for strongops command

### DIFF
--- a/lib/commands/strongops.js
+++ b/lib/commands/strongops.js
@@ -114,14 +114,17 @@ exports.test.cmd = strongops;
  * @param {String} err An error string message.
  */
 function getErrorForUser(err) {
-  // Do not like the inconsistency
-  var ERR_INVALID_CREDENTIALS = '[Error: Invalid Credentials]';
-  var ERR_USER_EXISTS = 'Error: user exists';
+  var ERR_INVALID_CREDENTIALS = 'Invalid Credentials';
+  var ERR_USER_EXISTS = 'Conflict: existing_user_login';
+  var ERR_EMAIL_EXISTS = 'Conflict: existing_user_email';
 
-  if (err == ERR_USER_EXISTS)
+  if (err.message == ERR_USER_EXISTS)
+    return 'Error: A user with that username already exists.';
+
+  if (err.message == ERR_EMAIL_EXISTS)
     return 'Error: A user with that email already exists.';
 
-  if (err == ERR_INVALID_CREDENTIALS)
+  if (err.message == ERR_INVALID_CREDENTIALS)
     return 'Error: Either the user is not registered or has a different password.';
 
   return ('Error: '+util.inspect(err));
@@ -196,11 +199,11 @@ function doUserReg(overrides, defaults, options, cb) {
       console.log(
         '\nYou are now registered. Welcome to StrongOps!\n' +
         '\n' +
-        'Note that what you specified for “Email Address” is actually the\n' +
-        'username you will need to use to create an account on strongloop.com.\n' +
-        'So, head on over to strongloop.com, click on Login > Register in the\n' +
-        'upper right-hand corner and create an account with the the same email\n' +
-        'and password you provided at the terminal.\n' +
+        'Restart your app and go to https://strongops.strongloop.com to see\n' +
+        'the stats reported by your app in the dashboard.\n' +
+        '\n' +
+        'Note that what you specified for "username" is the login you will\n' +
+        'use on https://www.strongloop.com or https://strongops.strongloop.com\n' +
         '\n' +
         'You are now ready to view your dashboard. Let\'s have a look.' +
         '\n'
@@ -259,7 +262,7 @@ exports.test.saveCredentials = saveCredentials;
  */
 function strongOpsLogin(userEnteredData, options, cb) {
   strongopsReg.login(userEnteredData, function(err, userData) {
-    if (err) return cb(util.inspect(err));
+    if (err) return cb(err);
 
     if (!is.obj(userData))
       return cb('Error on strongops login',userData);
@@ -612,7 +615,7 @@ function promptUserForReg(overrides, defaults, cb) {
 exports.test.promptUserForReg = promptUserForReg;
 
 /**
- * Get the command lines options for user name, email and password from the 
+ * Get the command lines options for user name, email and password from the
  * command line and place them in an overrides structure.
  */
 function getCmdLineOverrides(options) {
@@ -723,6 +726,14 @@ function getPromptSchema(defaults) {
   // The prompt schema describes the data we need the user to enter.
   var promptSchema = {
     properties: {
+      username: {
+        description: 'username',
+        type: 'string',
+        pattern: /^[A-Za-z0-9_@\s\.\-\*]+$/,
+        message: 'A username may only contain alphanumeric characters plus' +
+          ' these: _, space, ., -, *, and @',
+        required: true
+      },
       name: {
         description: 'full name ',
         type: 'string',
@@ -781,12 +792,12 @@ function getLoginPromptSchema(defaults) {
   // The prompt schema describes the data we need the user to enter.
   var promptSchema = {
     properties: {
-      email: {
-        description: 'email address',
+      username: {
+        description: 'strongloop.com username',
         type: 'string',
-        default: defaults.email,
-        pattern: /^([^\x00-\x20\x22\x28\x29\x2c\x2e\x3a-\x3c\x3e\x40\x5b-\x5d\x7f-\xff]+|\x22([^\x0d\x22\x5c\x80-\xff]|\x5c[\x00-\x7f])*\x22)(\x2e([^\x00-\x20\x22\x28\x29\x2c\x2e\x3a-\x3c\x3e\x40\x5b-\x5d\x7f-\xff]+|\x22([^\x0d\x22\x5c\x80-\xff]|\x5c[\x00-\x7f])*\x22))*\x40([^\x00-\x20\x22\x28\x29\x2c\x2e\x3a-\x3c\x3e\x40\x5b-\x5d\x7f-\xff]+|\x5b([^\x0d\x5b-\x5d\x80-\xff]|\x5c[\x00-\x7f])*\x5d)(\x2e([^\x00-\x20\x22\x28\x29\x2c\x2e\x3a-\x3c\x3e\x40\x5b-\x5d\x7f-\xff]+|\x5b([^\x0d\x5b-\x5d\x80-\xff]|\x5c[\x00-\x7f])*\x5d))*$/,
-        message: 'An email must be a valid address, qualified with a domain.',
+        pattern: /^[A-Za-z0-9_@\s\.\-\*]+$/,
+        message: 'A username may only contain alphanumeric characters plus' +
+          ' these: _, space, ., -, *, and @',
         required: true
       },
       password: {


### PR DESCRIPTION
Take username for authentication or new registrations.

Adjusted the error handling based on NodeFly/nodefly-registration now
always returning an error object for errors.

Changes messaging to communicate that the username is the login for
either strongloop.com or strongops.

_note_ PR recreated by me so  that I can release master with loopback changes. We'll delay merge of this until just before release of SSO.
