### PR TITLE
Co-install supervisor and cluster-control CLIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "colors": "~0.6.1",
     "read": "~1.0.5",
     "inflection": "~1.2.6",
-    "loopback-workspace": "~2.2.0",
+    "loopback-workspace": "~2.3.0",
     "mkdirp": "~0.3.5",
     "which": "~1.0.5",
     "strong-cluster-control": "~0.2.0",


### PR DESCRIPTION
/to @chandadharap @raymondfeng 

I want to re-release loopback-workspace and then strong-cli, this will complete the strong-supervisor publish (https://strongloop.atlassian.net/browse/SLN-724).

strong-supervisor is published

explicit calls to strong-agent and strong-cluster-control were removed from loopback-workspace and sls-sample-app master branches

for that removal to be seen, strong-cli needs re-releasing

also, to make the sl-run and clusterctl utilities get co-installed with slc, the package.json changes in this PR are needed
