### PR TITLE
Report failure to read a json file

### DIFF
--- a/lib/commands/strongops.js
+++ b/lib/commands/strongops.js
@@ -402,7 +402,7 @@ function writeTo(file, userData, createIfNotThere, cb) {
     // case for package.json
     saveCredentialsToFile({strongloop: userData}, file, function(err) {
       if (err)
-        displayError('Error writing to '+file+': '+JSON.stringify(err));
+        displayError(util.format('Error writing to \'%s\':', file, err));
       else {
         whereSaved += ((whereSaved.length === 0) ? '' : ', ') + file;
         timesSaved++;
@@ -474,7 +474,7 @@ function saveCredentialsToFile(data, file, cb) {
     return cb('The file '+file+' does not exist.');
   }
   jsonFile(file, function (err, fileObj) {
-    if (err) return cb(err);
+    if (err) return cb(util.format('read failed (%s)', err.message || err));
 
     fileObj.set(data);
     fileObj.save(function(err) {


### PR DESCRIPTION
With an invalid package.json, such as an empty one, `slc strongops
--package` was reporting errors such as:

   Error writing to ./package.json: {}

After this change, the error is:

  Error writing to './package.json': read failed (Unexpected end of input)
