### PR TITLE
strongops cmd now uses public json-file-plus.

### DIFF
--- a/lib/commands/strongops.js
+++ b/lib/commands/strongops.js
@@ -477,7 +477,7 @@ function saveCredentialsToFile(data, file, cb) {
     if (err) return cb(err);
 
     fileObj.set(data);
-    fileObj.save(file, function(err) {
+    fileObj.save(function(err) {
       return cb(err);
     });
   });

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "prepublish": "./prepublish.sh"
   },
   "bundledDependencies": [
-    "nodefly-register",
-    "json-file-plus"
+    "nodefly-register"
   ],
   "dependencies": {
     "npm": "~1.3.5",
@@ -29,7 +28,7 @@
     "async": "~0.2.9",
     "commander": "~1.1.1",
     "ini": "~1.1.0",
-    "json-file-plus": "strongloop/node-json-file",
+    "json-file-plus": "~0.2.2",
     "optimist": "~0.5.0",
     "node-inspector": "~0.5.0",
     "opener": "~1.3.0",


### PR DESCRIPTION
Once this is merged, we can delete the strongloop/node-file-plus.git repository, we are no longer floating the patch.

Note that even to support the install of older versions of strong-cli, our fork repo above isn't necessary, because the json-file-plus dependency was bundled into strong-cli.
