### PR TITLE
Simplify success message.

### DIFF
--- a/lib/commands/strongops.js
+++ b/lib/commands/strongops.js
@@ -196,13 +196,8 @@ function doUserReg(overrides, defaults, options, cb) {
       console.log(
         '\nYou are now registered. Welcome to StrongOps!\n' +
         '\n' +
-        'Note that what you specified for “Email Address” is actually the\n' +
-        'username you will need to use to create an account on strongloop.com.\n' +
-        'So, head on over to strongloop.com, click on Login > Register in the\n' +
-        'upper right-hand corner and create an account with the the same email\n' +
-        'and password you provided at the terminal.\n' +
-        '\n' +
-        'You are now ready to view your dashboard. Let\'s have a look.' +
+        'You are now ready to view your dashboard. Let\'s have a look: ' +
+        'https://strongops.strongloop.com' +
         '\n'
       );
       cb(undefined, userData);


### PR DESCRIPTION
@sam-github 

Removed the unnecessary step of telling users they have to create an
account with a matching email.

Also through in a link to the dashboard after the prompt to go there.
