### PR TITLE
preinstall: update peerDeps before global install

### DIFF
--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -12,15 +12,7 @@ module.exports = function(argv, options, loader) {
 
   console.log('strong-cli at %s; trying self-update...', VERSION);
 
-  var deps = Object.keys(PACKAGE.peerDependencies);
-
-  map(deps, function(name, callback) {
-    install(name, function() {
-      // Discard return value, npm install fails for many reasons we don't care
-      // about, we will determine success/fail using other means.
-      return callback();
-    });
-  }, checkVersions);
+  checkVersions();
 
   function install(name, callback) {
     console.log('npm install -g %s; this may take a moment...', name);

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "lint": "jshint --exclude test/sandbox *.js lib test",
     "test": "mocha --reporter spec",
+    "preinstall": "node preinstall.js",
     "prepublish": "./prepublish.sh"
   },
   "bundledDependencies": [

--- a/preinstall.js
+++ b/preinstall.js
@@ -1,0 +1,46 @@
+// preinstall script for updating globally installed peerDependencies
+
+var globalInstall = process.env.npm_config_global == 'true';
+
+if (!globalInstall) {
+  console.log('Skipping peerDependency preinstall for non-global install');
+  return;
+}
+
+var path = require('path');
+var npmPath = path.resolve(path.dirname(process.env.npm_execpath), '..');
+var npm = require(npmPath);
+
+var debug_enabled = process.env.DEBUG || process.env.npm_config_debug;
+var debug = debug_enabled ? console.error : function noop() {};
+var info = console.log;
+var error = console.error;
+
+npm.load({ loglevel: 'silent' }, installPeerDependencies);
+
+function installPeerDependencies(err, npm) {
+  if (err) {
+    error('Error loading npm, skipping peerDependencies preinstall');
+    debug(err);
+    return;
+  }
+
+  var peerDeps = require('./package.json').peerDependencies;
+  var targets = [];
+
+  for (name in peerDeps) {
+    targets.push(name + '@' + peerDeps[name]);
+  }
+
+  info('Attempting to pre-install peerDependencies:\n  %s\n',
+    targets.join('\n  '));
+
+  npm.commands.install(targets, function(err, res) {
+    if (err) {
+      error('Error while pre-installing peerDependencies');
+    } else {
+      info('Updated globals:', targets);
+    }
+    debug(err, res);
+  });
+}


### PR DESCRIPTION
Using node as a portable scripting language, install adequate versions
of our peerDependencies globally when we are installed globally
ourselves.

@sam-github an alternative to `slc update`?
- It should be portable because it is node, not bash
- It can install preferred versions since it runs after package.json has been expanded
- It _should_ "just work" with `npm -g update strong-cli`
