### PR TITLE
Partially revert 7479d2250: Fix windows spawn

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -5,8 +5,7 @@ module.exports = function Command(command, npmModule) {
   return function(argv, options, loader) {
     var options = {
       env: process.env,
-      stdio: 'inherit',
-      windowsVerbatimArguments: true
+      stdio: 'inherit'
     };
 
     // Because the commands are node scripts, on Windows, they are wrapped in a
@@ -18,9 +17,10 @@ module.exports = function Command(command, npmModule) {
       var quotedArgs = argv.map(windowsQuoteArg).join('');
       var file = 'cmd.exe';
       var args = ['/s', '/c', '"' + command + quotedArgs + '"'];
+      options.windowsVerbatimArguments = true;
     } else {
-      var file = '/bin/sh';
-      var args = ['-c', command].concat(argv);
+      var file = command;
+      var args = argv;
     }
 
     return spawn(file, args, options)


### PR DESCRIPTION
That commit fixed windows, but changed how slc would call `cmd arg1 arg2` on unix to:

```
  /bin/sh -c cmd arg1 arg2
```

the effect of which is that cmd would be executed with no arguments. slc
run, slc debug, etc., would all appear to work, unless arguments were
supplied, in which case they would not be passed to the cmd.

With this change, the non-windows platform goes back to its previous working code, see 7479d2250.
