### PR TITLE
example: remove non-loopback examples

### DIFF
--- a/man/example
+++ b/man/example
@@ -13,7 +13,7 @@ OOPPTTIIOONNSS
               print usage information
 
        ----nnoo--iinnssttaallll
-              skip the ssllcc nnppmm iinnssttaallll step after example is created
+              skip the nnppmm iinnssttaallll step after example is created
 
        ttyyppee   one  of  the  supported  example  types,  see below (defaults to
               ssuuiittee)
@@ -26,22 +26,9 @@ OOPPTTIIOONNSS
        +o   ssuuiittee:  LoopBack  API server, demonstrates LoopBack integrated with
            StrongNode, this is the default type
 
-       +o   cchhaatt: web chat  application,  demonstrates  socket.io  and  express
-           integrated with StrongNode clustering
-
-       +o   uurrllssaavveerr: document storage API server, demonstrates creating an API
-           server with express, request, Q, and StrongNode clustering
-
-       +o   bblloogg: weblog application, demonstates an express web app integrated
-           with StrongNode clustering
-
 EExxaammpplleess
        Create the suite example:
 
                slc example
 
-       Create the chat example, in a specific path:
-
-               slc example chat example/my-chat
-
-                                 January 2014                        EXAMPLE()
+                                  March 2014                         EXAMPLE()

--- a/man/example.md
+++ b/man/example.md
@@ -11,7 +11,7 @@ Create StrongLoop example applications.
 * `-h`, `--help`:
   print usage information
 * `--no-install`:
-  skip the `slc npm install` step after example is created
+  skip the `npm install` step after example is created
 * `type`:
    one of the supported example types, see below (defaults to `suite`)
 * `path`:
@@ -21,19 +21,9 @@ Supported example types are:
 
 - `suite`: LoopBack API server, demonstrates LoopBack integrated with
   StrongNode, this is the default type
-- `chat`: web chat application, demonstrates socket.io and express integrated
-  with StrongNode clustering
-- `urlsaver`: document storage API server, demonstrates creating an API server
-  with express, request, Q, and StrongNode clustering
-- `blog`: weblog application, demonstates an express web app integrated with
-  StrongNode clustering
 
 ### Examples
 
 Create the suite example:
 
         slc example
-
-Create the chat example, in a specific path:
-
-        slc example chat example/my-chat

--- a/prepublish.sh
+++ b/prepublish.sh
@@ -3,7 +3,7 @@
 set -e
 
 echo Updating example dependencies
-EXAMPLES="sls-sample-app sn-example-blog sn-example-chat sn-example-urlsaver"
+EXAMPLES="sls-sample-app"
 BRANCHES=`sl-install branches`
 rm -rf data
 mkdir -p data


### PR DESCRIPTION
The examples aren't relevant to loopback, so remove them from the
scaffolding. They are still available as public repos in github.

/to @crandmck @raymondfeng @jimmygsl 

Rand: Might have implications on our docs

Raymond: LGTY?

Jimmy: FYI, don't think they are relevant, but just in case
