### PR TITLE
Fix #110: explicitly depend on npm

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -3,24 +3,8 @@
  */
 
 var path = require('path');
-var npm = null;
-var npmPath = 'npm';
-try {
-  npm = require(npmPath);
-} catch (err) {
-  if (process.platform === 'win32') {
-    // On Windows, the built-in npm module is installed to 
-    // C:\Program Files\nodejs\node_modules\npm.
-    // But global modules installed using 'npm install -g' are under
-    // C:\Users\vagrant\AppData\Roaming\npm\node_modules
-    // Try to find the npm module relative the node execPath
-    npmPath = path.join(process.execPath, '..', 'node_modules/npm');
-    npm = require(npmPath);
-  } else {
-    throw err;
-  }
-}
-var log = require(path.join(npmPath, 'node_modules/npmlog'));
+var npm = require('npm');
+var log = require('npm/node_modules/npmlog');
 var assert = require('assert');
 var debug = require('debug')('slc');
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "mkdirp": "~0.3.5",
     "which": "~1.0.5",
     "fs.extra": "~1.2.1",
-    "cpr": "~0.1.1"
+    "cpr": "~0.1.1",
+    "npm": "~1.4.6"
   },
   "devDependencies": {
     "jshint": "~2.1.10",


### PR DESCRIPTION
In "normal" node installs, npm is globally installed, and requireable by
globally installed modules. However, not in Windows, and also not with
OS X homebrew. Change to useing an explicit dependency on npm.
