### PR TITLE
preinstall: Use separate cache for preinstall

### DIFF
--- a/preinstall.js
+++ b/preinstall.js
@@ -19,9 +19,8 @@ var info = console.log;
 var error = console.error;
 
 var tmpPath = path.resolve(os.tmpdir(), 'slc-install');
-var tmpStat = fs.statSync(tmpPath);
 
-if (!tmpStat.isDirectory()) {
+if (!fs.existsSync(tmpPath)) {
   fs.mkdirSync(tmpPath, 0700);
 }
 


### PR DESCRIPTION
To work around a race condition when npm calls itself, use a separate
npm cache directory when performing the pre-install of peerDependencies.

Fixes #123 
