### PR TITLE
version: add peer dependencies to `slc --version`

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -95,9 +95,7 @@ function run(argv) {
     return self.printUsage('slc');
   } else if (argv[0] === '-v' || argv[0] === '--version' ||
              argv[0] === 'version') { // For backards compatibility with docs
-    return console.log('slc v%s (node %s)',
-      require('../package.json').version,
-      process.version);
+    return require('./version')();
   } else if (!options._.length) {
     return self.printUsage('slc');
   } else {

--- a/lib/version.js
+++ b/lib/version.js
@@ -1,0 +1,28 @@
+var path = require('path');
+
+var PACKAGE = require('../package.json');
+
+function report(name, version) {
+  if(version != null) {
+    console.log('%s v%s', name, version);
+  } else {
+    console.log('%s peer-dependency not found; try `slc update`', name)
+  }
+}
+
+function check(name) {
+  try {
+    var v = require(path.join(name,'package.json')).version;
+    report(name, v);
+  } catch(er) {
+    report(name);
+  }
+}
+
+module.exports = function() {
+  console.log('strong-cli v%s (node %s)',
+      PACKAGE.version,
+      process.version);
+  Object.keys(PACKAGE.peerDependencies)
+    .map(check);
+};


### PR DESCRIPTION
This is easy way to solve the "I tried "slc peer" with slc version a.b.c" and it doesn't work, wherein there is no way to know the version of blah that is being used.

Other ways to implement are to actually call `slc peer -v` foreach peer, or to do an `npm ls -g --json` and parse it to find the blah.

I favor the current approach in the short term, its quick, easy, and does not appear to me to depend on any internal details of npm packaging and installation (other than that it won't work when strong-cli is npm linked).
