### PR TITLE
version: report peer version using --version

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -1,9 +1,15 @@
+var assert = require('assert');
+var debug = require('debug')('slc');
 var path = require('path');
+var shell = require('shelljs');
+var util = require('util');
 
 var PACKAGE = require('../package.json');
 
 function report(name, version) {
   if(version != null) {
+    // Normalize version, some print leading 'v', some don't.
+    version = version.replace(/^v/, '');
     console.log('%s v%s', name, version);
   } else {
     console.log('%s peer-dependency not found; try `slc update`', name)
@@ -11,6 +17,20 @@ function report(name, version) {
 }
 
 function check(name) {
+  try {
+    var scripts = require(path.join(name,'package.json')).bin;
+    var script = Object.keys(scripts)[0];
+    var cmd = util.format('%s --version', script);
+    var output = shell.exec(cmd, {silent:true});
+    assert.equal(output.code, 0, 'status of ' + cmd);
+    var v = output.output.split('\n')[0];
+    assert(v && v.length > 0, 'output of ' + cmd);
+    report(name, v);
+    return;
+  } catch (er) {
+    debug('Failed to run %s: %s', cmd, er);
+  }
+
   try {
     var v = require(path.join(name,'package.json')).version;
     report(name, v);

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "which": "~1.0.5",
     "fs.extra": "~1.2.1",
     "cpr": "~0.1.1",
-    "npm": "~1.4.6"
+    "npm": "~1.4.6",
+    "shelljs": "~0.3.0"
   },
   "devDependencies": {
     "jshint": "~2.1.10",


### PR DESCRIPTION
By calling the peer's script with --version, we can make `slc --version`
report the version as the peer chooses, instead of only the package
version, like:

```
% slc -v
strong-cli v2.5.3 (node v0.10.26)
node-inspector v0.8.0
strong-cluster-control v0.4.0
strong-registry v1.1.0
strong-supervisor v0.2.2 (strong-agent v0.4.8, strong-cluster-control v0.4.0)
```

Prior to this, strong-agent and strong-cluster-control versions would be
unknown.
