### PR TITLE
command: always set CMD so children can use it

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -8,6 +8,9 @@ module.exports = function Command(command, npmModule) {
       stdio: 'inherit'
     };
 
+    // Transmit full original command name to children
+    options.env.CMD = 'slc ' + process.env.SLC_COMMAND;
+
     // Because the commands are node scripts, on Windows, they are wrapped in a
     // command file, and command files cannot be spawned, since they aren't
     // actually executable binaries. So, we call cmd.exe to spawn them, but

--- a/lib/commands/debug.js
+++ b/lib/commands/debug.js
@@ -1,2 +1,1 @@
-process.env.CMD = 'slc debug'; // Used by node-debug in --help
 module.exports = require('../command')('node-debug', 'node-inspector');


### PR DESCRIPTION
lib/loader.js sets env.SLC_COMMAND, but then all children need to
prepend "slc " to this get the original command name (used in usage
messages). node-debug uses the less slc-specific CMD. With this change,
CMD is set to the full "slc whatever" for all sub-commands, so
node-debug is less of a special case.
