### PR TITLE
lb: update the usage of workspace and juggler API

### DIFF
--- a/lib/commands/lb.js
+++ b/lib/commands/lb.js
@@ -109,6 +109,8 @@ module.exports = function (argv, options, loader) {
 
   function createModel(config) {
     var project;
+    var properties = config.properties;
+    delete config.properties;
 
     async.waterfall([
       function(callback) {
@@ -116,26 +118,30 @@ module.exports = function (argv, options, loader) {
       },
       function(isValid, message, callback) {
         if(isValid) {
-          Project.loadFromFiles(process.cwd(), callback);
+          Project.loadFromFiles(process.cwd(), function(err, obj) {
+            project = obj;
+            callback(err);
+          });
         } else {
           callback('Project at ' + process.cwd() + ' is not an existing valid project ('+ message +').');
         }
       },
-      function(project, callback) {
-        project.models.create(config, function(err) {
-          if(err) {
-            if(isValidationErr(err)) {
-              printValidationErr(err);
-              callback();
-            } else {
-              callback(err);
-            }
-          }
-
-          project.saveToFiles(process.cwd(), callback);
-        });
+      function(callback) {
+        project.models.create(config, callback);
       },
       function(model, callback) {
+        async.each(Object.keys(properties), function(name, next) {
+          var data = properties[name];
+          data.name = name;
+          model.properties.create(data, next);
+        }, function(err) {
+          callback(err);
+        });
+      },
+      function(callback) {
+        project.saveToFiles(process.cwd(), callback);
+      },
+      function(callback) {
         console.log('Created ' + config.name.green + ' model.');
       }
     ], error);
@@ -173,15 +179,10 @@ module.exports = function (argv, options, loader) {
       function(project, callback) {
         project.dataSources.create(config, function(err) {
           if(err) {
-            if(isValidationErr(err)) {
-              printValidationErr(err);
-              callback('validation failed...');
-            } else {
-              callback(err);
-            }
+            callback(err);
+          } else {
+            project.saveToFiles(process.cwd(), callback);
           }
-
-          project.saveToFiles(process.cwd(), callback);
         });
       },
       function(callback) {
@@ -272,7 +273,11 @@ module.exports = function (argv, options, loader) {
   }
 
   function error(err) {
-    loader.error(err);
+    if (isValidationErr(err)) {
+      printValidationErr(err);
+    } else {
+      loader.error(err);
+    }
   }
 
   function startModelPrompts(name, config, fn) {
@@ -446,13 +451,13 @@ module.exports = function (argv, options, loader) {
   }
 
   function printValidationErr(err) {
-    if(err.context) {
-      console.error('Invalid "%s"', err.context);
+    if(err.details.context) {
+      console.error('Invalid "%s"', err.details.context);
     }
-    if(err.codes) {
+    if(err.details.codes) {
       console.error('Could not validate:')
-      Object.keys(err.codes).forEach(function(code) {
-        console.error(' - %s of "%s"', err.codes[code], code);
+      Object.keys(err.details.codes).forEach(function(code) {
+        console.error(' - %s of "%s"', err.details.codes[code], code);
       })
     }
   }


### PR DESCRIPTION
Use `model.properties.create()` to add properties to a model (this was a breaking change in loopback-workspace 2.5.0 - strongloop/loopback-workspace#47). 

Use `err.details.context` and `err.details.codes` when printing ValidationError (there was a breaking change in loopback-datasource-juggler a long time ago).

/to @ritch or @sam-github please review
