### PR TITLE
strongops: Add --license option for saving license

### DIFF
--- a/lib/commands/strongops.js
+++ b/lib/commands/strongops.js
@@ -171,6 +171,31 @@ function doUserReg(overrides, defaults, options, cb) {
 }
 
 function doUserLogin(overrides, defaults, options, cb) {
+  if (options.license) {
+    try {
+      var license = require('strong-agent/lib/license')(options.license);
+      console.log('Skipping login, checking pre-defined license key.');
+      console.log(['License details:',
+                   '  email: %s',
+                   '  product: %s',
+                   '  features: %s',
+                   '  activation: %s',
+                   '  expiration: %s'].join('\n'),
+                   license.details.email, license.details.product,
+                   license.details.features.join(', '),
+                   license.details.activationDate,
+                   license.details.expirationDate);
+      if (!license.covers('agent')) {
+        return cb('Invalid license, please contact sales@strongloop.com');
+      }
+      if (!license.covers(false, false, new Date())) {
+        return cb('Expired license, please contact sales@strongloop.com');
+      }
+      return cb(null, { agent_license: options.license });
+    } catch (e) {
+      return cb('Error validating license: ' + e);
+    }
+  }
   // get the name and email only for login
   promptUserForLogin(overrides, defaults, function(err, userEnteredData) {
     // if we get an invalid response, asume users want to exit

--- a/man/strongops.md
+++ b/man/strongops.md
@@ -18,6 +18,12 @@ There are no interactive prompts for data specified on the command line.
   address found in your `~/.gitconfig` or `~/.npmrc` is offered as the default.
 * `--password`:
   Specify your StrongOps password, e.g.: `--password 12345678`
+* `--license`:
+  Write the specified strong-agent license key instead of authenticating with
+  the StrongOps servers and storing a StrongOps agent API key. If both types of
+  keys are required, `slc strongops` can be run again without the `--license`
+  option and the file will be updated with additional credentials.
+  e.g.: `--license XXXXXYYYYYYZZZZZZ`.
 * `--nosave`:
   Prevent saving of StrongOps account credentials, this overrides any save
   option.
@@ -44,3 +50,8 @@ Use the `--email` and `--password` options for non-interactive  registration
 with no prompts:
 
         $ slc strongops --email "bw@example.com" --password "12345678"
+
+To decode and view the details of a strong-agent license without modifying
+any files, where XXYYZZ is your license key:
+
+        $ slc strongops --nosave --license XXYYZZ

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "optimist": "~0.5.0",
     "prompt": "~0.2.11",
     "read": "~1.0.5",
+    "strong-agent": "~0.4.14",
     "strong-build": "~0.1.0",
     "strong-deploy": "~0.1.0",
     "strong-pm": "~0.1.0",


### PR DESCRIPTION
When the --license option is specified no authentication is done, but
the given license key is validated and then written to strongloop.json
if it is valid.

If a user also needs to use StrongOps, they can run the command without
the --license option to fill in the authentiction details.

SLN-1223 #refs

@sam-github @kraman PTAL
@chandadharap @sumitha does this look usable?
