### PR TITLE
Add `slc arc` command

### DIFF
--- a/lib/commands/arc.js
+++ b/lib/commands/arc.js
@@ -1,0 +1,2 @@
+process.env.CMD = 'slc arc'; // Used by strong-arc in --help
+module.exports = require('../command')('bin/cli', 'strong-arc');

--- a/lib/version.js
+++ b/lib/version.js
@@ -33,6 +33,7 @@ function formatReport(info, prefix) {
 // those that the slc commands directly depend on. In addition, report
 // the version of strong-agent.
 var REPORT_DEPENDENCIES = [
+  'strong-arc',
   'strong-build',
   'strong-supervisor',
   'node-inspector',

--- a/man/slc
+++ b/man/slc
@@ -11,12 +11,14 @@ SSYYNNOOPPSSIISS
 
 OOPPTTIIOONNSS
        --hh, ----hheellpp
-              print usage for slc (use ssllcc ccmmdd --hh for help on ccmmdd), and exit.
+              print  usage for slc (use ssllcc ccmmdd --hh for help on ccmmdd), and exit.
 
        --vv, ----vveerrssiioonn
               print version of slc and node, and exit.
 
 CCOOMMMMAANNDDSS
+       +o   aarrcc: launch StrongLoop GUI
+
        +o   bbuuiilldd: build a node application package using strong-build
 
        +o   cclluusstteerrccttll: same as rruunnccttll
@@ -29,10 +31,10 @@ CCOOMMMMAANNDDSS
 
        +o   eexxaammppllee: create example applications
 
-       +o   llbb:  create LoopBack 1.x workspaces, applications, and models (dep-
+       +o   llbb: create LoopBack 1.x workspaces, applications, and models  (dep-
            recated)
 
-       +o   llooooppbbaacckk: create LoopBack 2.x  applications,  datasources,  models,
+       +o   llooooppbbaacckk:  create  LoopBack  2.x applications, datasources, models,
            acls, and relations
 
        +o   ppmm: manage deployed node applications with strong-pm
@@ -41,7 +43,7 @@ CCOOMMMMAANNDDSS
 
        +o   ppmm--iinnssttaallll: install strong-pm as an OS service
 
-       +o   rreeggiissttrryy:  switch  registries and promote packages with strong-reg-
+       +o   rreeggiissttrryy: switch registries and promote packages  with  strong-reg-
            istry
 
        +o   rruunn: run a node application using strong-supervisor
@@ -62,4 +64,4 @@ EEXXAAMMPPLLEESS
            $ slc runctl status
            $ slc debug app.js
 
-                                  August 2014                            SLC()
+                                 November 2014                           SLC()

--- a/man/slc.md
+++ b/man/slc.md
@@ -17,6 +17,7 @@ Command-line tool for development and control of a Node application.
 
 ### COMMANDS
 
+* `arc`: launch StrongLoop GUI
 * `build`: build a node application package using strong-build
 * `clusterctl`: same as `runctl`
 * `debug`: debug a node script using node-inspector

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "prompt": "~0.2.11",
     "read": "~1.0.5",
     "strong-agent": "^1.0.0",
+    "strong-arc": "^0.3.0",
     "strong-build": "^1.0.0",
     "strong-deploy": "^1.0.0",
     "strong-pm": "^1.0.0",


### PR DESCRIPTION
A part of https://github.com/strongloop/strong-arc/issues/380

The command corresponds to `strong-arc` from `strong-arc`.

I am using `strong-arc@0.3.0` as currently published in npmjs.org. We should upgrade the dep specifier to `strong-arc@^1.0.0` after Arc's GA release.

I am not sure what is the cause of whitespace changes in `man/slc`. My Ronn version is v0.7.3, perhaps the file was generated by an older version before?

/to @sam-github please review
/cc @altsang @chandadharap 
