### PR TITLE
Upgrade `slc debug` to use node-inspector 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "is2": "~0.0.3",
     "json-file-plus": "^2.0.0",
     "loopback-sdk-angular-cli": "1.x",
-    "node-inspector": "~0.7.0",
+    "node-inspector": "~0.9.2",
     "nodefly-register": "~0.3.2",
     "nopt": "~3.0.1",
     "optimist": "^0.6.1",


### PR DESCRIPTION
@bajtos is it safe for `slc debug` to use node-inspector 0.8.0 instead of 0.7.3?