### PR TITLE
package: use git clone to get example app

### DIFF
--- a/prepublish.sh
+++ b/prepublish.sh
@@ -8,3 +8,4 @@ mkdir data
 git clone --depth=1 --branch=production \
   https://github.com/strongloop/loopback-example-app.git \
   data/loopback-example-app
+rm -rf data/loopback-example-app/.git


### PR DESCRIPTION
This drastically simplifies the prepublish script, and also makes it MUCH faster (because it doesn't install the loopback deps).

@rmg What do you think?

It would also be quite easy to rewrite in shelljs at this point.
