### PR TITLE
Bundle adm-zip as workaround for broken dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,9 +83,11 @@
     "prepublish": "node ./prepublish.js"
   },
   "bundledDependencies": [
+    "adm-zip",
     "nodefly-register"
   ],
   "dependencies": {
+    "adm-zip": "0.4.4",
     "async": "^0.9.0",
     "colors": "^1.0.3",
     "cpr": "^0.3.2",


### PR DESCRIPTION
Bundle adm-zip@0.4.4 to pre-satisfy deeper dependencies on
adm-zip@~0.4.4 which was broken in 0.4.5 due to cthackers/adm-zip#121
and askovpen/node-fidonet-mailer-binkp-crypt#1.

This can be reverted once askovpen/node-fidonet-mailer-binkp-crypt#2
is merged and makes it into a relase of fidonet-mailer-binkp-crypt.

/cc @bnoordhuis @chandadharap @ShubhraKar 