### PR TITLE
strong-pm release cleanup

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,7 +11,7 @@
         "no-bitwise": 0,
         "no-caller": 2,
         "no-catch-shadow": 0,
-        "no-comma-dangle": 0,
+        "comma-dangle": 0,
         "no-cond-assign": 2,
         "no-console": 0,
         "no-constant-condition": 2,

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "strong-arc": "^1.0.0",
     "strong-build": "^1.0.0",
     "strong-deploy": "^1.0.0",
-    "strong-pm": "^2.0.0",
+    "strong-pm": "^3.0.0",
     "strong-registry": "^1.0.0",
     "strong-start": "^1.0.0",
     "strong-supervisor": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,8 @@
     "which": "~1.0.5"
   },
   "devDependencies": {
-    "jshint": "^2.5.10",
+    "eslint": "^0.16.1",
+    "jscs": "^1.11.3",
     "mocha": "^2.0.1",
     "nexpect": "^0.4.2"
   },


### PR DESCRIPTION
Fixes a couple problems since #201 was merged:
 * Updates strong-pm dependency since we accidentally skipped 2.x
 * Updates dev dependencies so that `npm run lint` works