### PR TITLE
Use strong-mesh-models for 'slc ctl'

### DIFF
--- a/lib/commands/ctl.js
+++ b/lib/commands/ctl.js
@@ -1,1 +1,1 @@
-module.exports = require('../command')('bin/sl-pmctl', 'strong-pm');
+module.exports = require('../command')('bin/sl-meshctl', 'strong-mesh-models');

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "strong-arc": "^1.0.0",
     "strong-build": "^1.0.3",
     "strong-deploy": "^1.0.0",
+    "strong-mesh-models": "^5.0.0",
     "strong-pm": "^3.0.0",
     "strong-registry": "^1.0.0",
     "strong-start": "^1.0.0",


### PR DESCRIPTION
As a side effect, this hoists the strong-mesh-models dependency of
some of the dependencies up to the top level which shortens the
maximum path length (mitigating #207) and reducing the overall
installation footprint by reducing module duplication.

See also strongloop-internal/scrum-nodeops#423