### PR TITLE
deps: hoist jsonstream@1.0.3 to top level

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "express-session": "^1.11.1",
     "inflight": "^1.0.4",
     "inherits": "^2.0.1",
+    "jsonstream": "^1.0.3",
     "lodash": "^3.0.0",
     "loopback": "^2.17.0",
     "loopback-boot": "^2.7.0",


### PR DESCRIPTION
Work around an upstream problem with a conflict between JSONStream and jsonstream.

@sam-github @chandadharap I'd like to merge this and publish as strongloop@3.1.2.