### PR TITLE
use SPDX expression for package license

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,10 +67,7 @@
     "url": "git://github.com/strongloop/strongloop.git"
   },
   "author": "engineering@strongloop.com",
-  "license": {
-    "name": "Dual Artistic/StrongLoop",
-    "url": "https://github.com/strongloop/strongloop/blob/master/LICENSE.md"
-  },
+  "license": "(Artistic-2.0 OR LicenseRef-LICENSE.md)",
   "readmeFilename": "README.md",
   "bin": {
     "slc": "./bin/slc",


### PR DESCRIPTION
Clears the warning that newer versions of npm print when installing.

Connect to strongloop-internal/scrum-nodeops#642

@bajtos @sam-github I believe this is the most "correct" way to express the StrongLoop license in SPDX. Thoughts?