### PR TITLE
[SEMVER-MAJOR] Remove lb-ng-doc to get rid of docular dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strongloop",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "StrongLoop Command Line Tools",
   "homepage": "http://www.strongloop.com",
   "keywords": [
@@ -70,8 +70,7 @@
   "readmeFilename": "README.md",
   "bin": {
     "slc": "./bin/slc.js",
-    "lb-ng": "./node_modules/loopback-sdk-angular-cli/bin/lb-ng",
-    "lb-ng-doc": "./node_modules/loopback-sdk-angular-cli/bin/lb-ng-doc"
+    "lb-ng": "./node_modules/loopback-sdk-angular-cli/bin/lb-ng"
   },
   "scripts": {
     "pretest": "eslint --ignore-path .gitignore . && jscs .",
@@ -81,7 +80,7 @@
     "async": "^0.9.0",
     "debug": "^2.1.0",
     "generator-loopback": "1.x",
-    "loopback-sdk-angular-cli": "1.x",
+    "loopback-sdk-angular-cli": "2.x",
     "node-inspector": "~0.7.0",
     "nodefly-register": "~0.3.2",
     "nopt": "~3.0.1",


### PR DESCRIPTION
See also https://github.com/strongloop/loopback-sdk-angular-cli/pull/36

/to @rmg or @sam-github please review
/cc @chandadharap 