### PR TITLE
Upgrade Node Inspector

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "debug": "^2.1.0",
     "generator-loopback": "1.x",
     "loopback-sdk-angular-cli": "2.x",
-    "node-inspector": "~0.7.0",
+    "node-inspector": "~0.12.7",
     "nodefly-register": "~0.3.2",
     "nopt": "~3.0.1",
     "optimist": "^0.6.1",


### PR DESCRIPTION
node-inspector(~0.7.0 - 0.7.4 to be specific)
breaks slc debug. Changing it to 0.12.7 -
latest fixes the issue.
Connect to #301
