### PR TITLE
Lock sqlite version to fix global installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "moment": "^2.10.0",
     "readable-stream": "^2.0.3",
     "spawn-sync": "^1.0.13",
-    "sqlite3": "^3.1.0",
+    "sqlite3": "3.1.4",
     "strong-debugger": "^1.0.0",
     "strong-remoting": "^2.0.0",
     "strong-swagger-ui": "^21.0.1",


### PR DESCRIPTION
* Newer versions of mapbox/node-sqlite3 are breaking API Connect and
  LoopBack installations

* Caused by 9a038b5 listing `node-pre-gyp` as a dep and installing it
  during `preinstall`

* See issue at https://github.com/mapbox/node-sqlite3/issues/720 for
  more details

Connect to #325 