### PR TITLE
Upgrade to sqlite3@^3.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "moment": "^2.10.0",
     "readable-stream": "^2.0.3",
     "spawn-sync": "^1.0.13",
-    "sqlite3": "3.1.4",
+    "sqlite3": "^3.1.6",
     "strong-debugger": "^1.0.0",
     "strong-remoting": "^2.0.0",
     "strong-swagger-ui": "^21.0.1",


### PR DESCRIPTION
* Fixes installation issues with `npm install -g strongloop` and `npm
  install -g apiconnect`

* They now bundle `node-pre-gyp`, see
  https://github.com/mapbox/node-sqlite3/commits/de2055b

* Initial bug discussion at
  https://github.com/mapbox/node-sqlite3/issues/720